### PR TITLE
Fix path not defined error stopping plugin from loading

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,5 +1,6 @@
 helpers = require('atom-linter')
 XRegExp = require('xregexp').XRegExp
+path    = require('path')
 
 module.exports =
     config:


### PR DESCRIPTION
On Mac 10.10.5 I was receiving an error (uploaded below) which was preventing the plugin from loading.

This adds a require for the _path_ module and fixes the bug in my case.
After this the plugin began to function, whereas the original [_linter-stylint_](https://github.com/AtomLinter/linter-stylint) plugin would not.

<img width="452" alt="safari - github com - - screen shot sep 28 2015 00 11 51" src="https://cloud.githubusercontent.com/assets/1646307/10125715/e6067436-6576-11e5-944e-99e933377484.png">
